### PR TITLE
ft[Extension]: Adds additional way of updating obstacle root_state

### DIFF
--- a/mppiisaac/planner/mppi.py
+++ b/mppiisaac/planner/mppi.py
@@ -68,7 +68,7 @@ class MPPIConfig(object):
     u_min: float = -1.0
     u_max: float = 1.0
     u_init: float = 0.0
-    U_init: Optional[List[float]] = None
+    U_init: Optional[List[List[float]]] = None
     u_scale: float = 1
     u_per_command: int = 1
     rollout_var_discount: float = 0.95


### PR DESCRIPTION
A couple of updates from testing with Heijn in the lab.

updates:
- Adds mass as parameter to the `add_box` method
- Uses the absolute path to search for the assets_root folder, so importing in another repo (like [mppi_isaac_ros](https://github.com/tud-airlab/mppi_isaac_ros)) can find the assets.
- Adds an additional way of updating the obstacle root states, by adding another parameter in the `compute_action` method. Needed because the pybullet FullSensor doesn't sense orientation afaik, therefore the old way of updating didn't work.