### PR TITLE
fix[Gravity]: enable gravity by default

### DIFF
--- a/conf/config_panda.yaml
+++ b/conf/config_panda.yaml
@@ -9,4 +9,5 @@ urdf_file: "panda_isaac/robots/franka_panda.urdf"
 ee_link: "panda_link7"
 fix_base: true
 flip_visual: true
+disable_gravity: true
 nx: 14

--- a/conf/config_panda_c_space_goal.yaml
+++ b/conf/config_panda_c_space_goal.yaml
@@ -8,4 +8,5 @@ n_steps: 1000
 urdf_file: "panda_bullet/panda.urdf"
 fix_base: true
 flip_visual: false
+disable_gravity: true
 nx: 14

--- a/mppiisaac/planner/isaacgym_wrapper.py
+++ b/mppiisaac/planner/isaacgym_wrapper.py
@@ -49,7 +49,8 @@ class IsaacGymWrapper:
         fix_base: bool,
         flip_visual: bool,
         num_envs: int = 0,
-        ee_link: str = None
+        ee_link: str = None,
+        disable_gravity: bool = False
     ):
         self.gym = gymapi.acquire_gym()
 
@@ -65,6 +66,8 @@ class IsaacGymWrapper:
         self._fix_base = fix_base
         self._flip_visual = flip_visual
         self._ee_link = ee_link
+        self._disable_gravity = disable_gravity
+
         self.start_sim()
 
     def start_sim(self):
@@ -89,6 +92,7 @@ class IsaacGymWrapper:
             asset_root=f"{file_path}/../../assets",
             fix_base_link=self._fix_base,
             flip_visual_attachments=self._flip_visual,
+            disable_gravity=self._disable_gravity
         )
 
         self.envs = [self.create_env(i) for i in range(self.num_envs)]
@@ -291,13 +295,13 @@ class IsaacGymWrapper:
         asset_root=f"{file_path}/../../assets",
         fix_base_link=False,
         flip_visual_attachments=False,
-        gravity=False,
+        disable_gravity=False,
     ):
         asset_options = gymapi.AssetOptions()
         asset_options.fix_base_link = fix_base_link
         asset_options.armature = 0.01
         asset_options.flip_visual_attachments = flip_visual_attachments
-        asset_options.disable_gravity = not gravity
+        asset_options.disable_gravity = disable_gravity
         return self.gym.load_asset(self.sim, asset_root, asset_file, asset_options)
 
     def set_dof_state_tensor(self, state):

--- a/mppiisaac/planner/mppi_isaac.py
+++ b/mppiisaac/planner/mppi_isaac.py
@@ -23,7 +23,8 @@ class MPPIisaacPlanner(object):
             cfg.fix_base,
             cfg.flip_visual,
             num_envs=cfg.mppi.num_samples,
-            ee_link=cfg.ee_link
+            ee_link=cfg.ee_link,
+            disable_gravity=cfg.disable_gravity
         )
 
         if prior:

--- a/mppiisaac/utils/config_store.py
+++ b/mppiisaac/utils/config_store.py
@@ -17,6 +17,7 @@ class ExampleConfig:
     urdf_file: str
     fix_base: bool
     flip_visual: bool
+    disable_gravity: bool = False
     differential_drive: bool = False
     wheel_base: float = 0
     wheel_radius: float = 0


### PR DESCRIPTION
The boxer wasn't working anymore because we disabled the gravity by default, so the panda works better.

I've created another parameter in the `ExampleConfig` to explicitly disable gravity, but it's enabled by default now.