### PR TITLE
Custom dynamics for single and multi-robot motion planning

### DIFF
--- a/conf/config_jackal_robot_custom_dynamics.yaml
+++ b/conf/config_jackal_robot_custom_dynamics.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - mppi: jackal
+
+goal: [2.0, 2.0]
+render: true
+n_steps: 1000
+nx: 4
+
+dt: 0.1
+
+actors: ['jackal']
+initial_actor_positions: [[0.0, 0.0, 0.05]]

--- a/conf/config_multi_jackal_custom_dynamics.yaml
+++ b/conf/config_multi_jackal_custom_dynamics.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - mppi: multi-jackal
+
+goal: [2.0, 0.0, -2.0, 0.0]
+render: true
+n_steps: 1000
+nx: 8
+
+dt: 0.1
+
+actors: ['jackal', 'jackal', 'xaxis', 'yaxis']
+initial_actor_positions: [[-2.0, 0.0, 0.0], [4.0, 0.0, 3.1415]]

--- a/conf/config_point_robot_custom_dynamics.yaml
+++ b/conf/config_point_robot_custom_dynamics.yaml
@@ -6,5 +6,7 @@ render: true
 n_steps: 1000
 nx: 6
 
+dt: 0.1
+
 actors: ['point_robot']
 initial_actor_positions: [[0.0, 0.0, 0.05]]

--- a/conf/config_point_robot_custom_dynamics.yaml
+++ b/conf/config_point_robot_custom_dynamics.yaml
@@ -1,0 +1,10 @@
+defaults:
+  - mppi: pointbot
+
+goal: [2.0, 2.0]
+render: true
+n_steps: 1000
+nx: 6
+
+actors: ['point_robot']
+initial_actor_positions: [[0.0, 0.0, 0.05]]

--- a/conf/mppi/multi-jackal.yaml
+++ b/conf/mppi/multi-jackal.yaml
@@ -3,8 +3,8 @@ defaults:
 
 mppi_mode: "halton-spline"  # halton-spline, simple
 sampling_method: "halton"   # halton, random
-num_samples: 100
-horizon: 20                 # At least 12 for Halton Sampling
+num_samples: 500
+horizon: 30                 # At least 12 for Halton Sampling
 device: "cuda:0"
 lambda_: 0.01
 u_min: [-1.5]

--- a/conf/mppi/pointbot.yaml
+++ b/conf/mppi/pointbot.yaml
@@ -3,7 +3,7 @@ defaults:
 
 mppi_mode: "halton-spline"  # halton-spline, simple
 sampling_method: "halton"   # halton, random
-num_samples: 100
+num_samples: 200
 horizon: 20                 # At least 12 for Halton Sampling
 device: "cuda:0"
 lambda_: 0.1

--- a/examples/jackal_robot_custom_dynamics.py
+++ b/examples/jackal_robot_custom_dynamics.py
@@ -126,12 +126,11 @@ def run_point_robot(cfg: ExampleConfig):
         # Calculate action with the fabric planner, slice the states to drop Z-axis [3] information.
         ob_robot = ob["robot_0"]
 
+        state = np.concatenate((ob_robot["joint_state"]["position"], ob_robot["joint_state"]["velocity"]))
+        
         t = time.time()
 
-        action = planner.compute_action(
-            q=ob_robot["joint_state"]["position"],
-            qdot=ob_robot["joint_state"]["velocity"],
-        )
+        action = planner.compute_action(state)
 
         print(f"Time: {(time.time() - t)} s")
         

--- a/examples/jackal_robot_custom_dynamics.py
+++ b/examples/jackal_robot_custom_dynamics.py
@@ -1,0 +1,146 @@
+import gym
+import numpy as np
+from urdfenvs.robots.generic_urdf import GenericDiffDriveRobot
+from urdfenvs.urdf_common.urdf_env import UrdfEnv
+from mppiisaac.planner.mppi_custom_dynamics import MPPICustomDynamicsPlanner
+import mppiisaac
+import hydra
+import yaml
+from yaml import SafeLoader
+from omegaconf import OmegaConf
+import os
+import torch
+from mpscenes.goals.static_sub_goal import StaticSubGoal
+from mppiisaac.utils.config_store import ExampleConfig
+import time
+from mppiisaac.dynamics.jackal_robot import jackal_robot_dynamics
+
+# MPPI to navigate a simple robot to a goal position
+
+
+class Objective(object):
+    def __init__(self, cfg, device):
+        self.nav_goal = torch.tensor(cfg.goal, device=cfg.mppi.device)
+
+    def compute_cost(self, state: torch.Tensor):
+        positions = state[:, 0:2]
+        rot_cost = torch.abs(state[:,5])
+        goal_dist = torch.linalg.norm(positions - self.nav_goal, axis=1)
+        return goal_dist * 1.0 + rot_cost * 0.05
+
+class Dynamics(object):
+    def __init__(self, cfg):
+        self.dt = cfg.dt
+
+    def simulate(self, states, control, t):
+        new_states, control = jackal_robot_dynamics(states, control, self.dt)
+        return (new_states, control)
+
+
+def initalize_environment(cfg) -> UrdfEnv:
+    """
+    Initializes the simulation environment.
+
+    Adds an obstacle and goal visualizaion to the environment and
+    steps the simulation once.
+
+    Params
+    ----------
+    render
+        Boolean toggle to set rendering on (True) or off (False).
+    """
+    with open(f'{os.path.dirname(mppiisaac.__file__)}/../conf/actors/jackal.yaml') as f:
+        heijn_cfg = yaml.load(f, Loader=SafeLoader)
+    urdf_file = f'{os.path.dirname(mppiisaac.__file__)}/../assets/urdf/' + heijn_cfg['urdf_file']
+    robots = [
+        GenericDiffDriveRobot(
+            urdf=urdf_file,
+            mode="vel",
+            actuated_wheels=[
+                "rear_right_wheel",
+                "rear_left_wheel",
+                "front_right_wheel",
+                "front_left_wheel",
+            ],
+            castor_wheels=[],
+            wheel_radius = 0.098,
+            wheel_distance = 2 * 0.187795 + 0.08,
+        ),
+    ]
+    env: UrdfEnv = gym.make("urdf-env-v0", dt=cfg.dt, robots=robots, render=cfg.render)
+    # Set the initial position and velocity of the point mass.
+    env.reset()
+    goal_dict = {
+        "weight": 1.0,
+        "is_primary_goal": True,
+        "indices": [0, 1],
+        "parent_link": 0,
+        "child_link": 1,
+        "desired_position": cfg.goal,
+        "epsilon": 0.05,
+        "type": "staticSubGoal",
+    }
+    goal = StaticSubGoal(name="simpleGoal", content_dict=goal_dict)
+    env.add_goal(goal)
+    return env
+
+
+def set_planner(cfg):
+    """
+    Initializes the mppi planner for the point robot.
+
+    Params
+    ----------
+    goal_position: np.ndarray
+        The goal to the motion planning problem.
+    """
+    # urdf = "../assets/point_robot.urdf"
+    objective = Objective(cfg, cfg.mppi.device)
+    dynamics = Dynamics(cfg)
+    planner = MPPICustomDynamicsPlanner(cfg, objective, dynamics.simulate)
+
+    return planner
+
+
+@hydra.main(version_base=None, config_path="../conf", config_name="config_jackal_robot_custom_dynamics.yaml")
+def run_point_robot(cfg: ExampleConfig):
+    """
+    Set the gym environment, the planner and run point robot example.
+    The initial zero action step is needed to initialize the sensor in the
+    urdf environment.
+
+    Params
+    ----------
+    n_steps
+        Total number of simulation steps.
+    render
+        Boolean toggle to set rendering on (True) or off (False).
+    """
+    env = initalize_environment(cfg)
+    planner = set_planner(cfg)
+
+    action = np.zeros(int(cfg.nx / 2))
+    ob, *_ = env.step(action)
+
+    for _ in range(cfg.n_steps):
+        # Calculate action with the fabric planner, slice the states to drop Z-axis [3] information.
+        ob_robot = ob["robot_0"]
+
+        t = time.time()
+
+        action = planner.compute_action(
+            q=ob_robot["joint_state"]["position"],
+            qdot=ob_robot["joint_state"]["velocity"],
+        )
+
+        print(f"Time: {(time.time() - t)} s")
+        
+        (
+            ob,
+            *_,
+        ) = env.step(action)
+    return {}
+
+
+if __name__ == "__main__":
+    res = run_point_robot()

--- a/examples/point_robot_custom_dynamics.py
+++ b/examples/point_robot_custom_dynamics.py
@@ -103,14 +103,14 @@ def run_point_robot(cfg: ExampleConfig):
         # Calculate action with the fabric planner, slice the states to drop Z-axis [3] information.
         ob_robot = ob["robot_0"]
 
-        # t = time.time()
+        t = time.time()
 
         action = planner.compute_action(
             q=ob_robot["joint_state"]["position"],
             qdot=ob_robot["joint_state"]["velocity"],
         )
 
-        # print(f"Time: {(time.time() - t)} s")
+        print(f"Time: {(time.time() - t)} s")
         
         (
             ob,

--- a/examples/point_robot_custom_dynamics.py
+++ b/examples/point_robot_custom_dynamics.py
@@ -12,6 +12,7 @@ import os
 import torch
 from mpscenes.goals.static_sub_goal import StaticSubGoal
 from mppiisaac.utils.config_store import ExampleConfig
+import time
 
 # MPPI to navigate a simple robot to a goal position
 
@@ -44,7 +45,7 @@ def initalize_environment(cfg) -> UrdfEnv:
     robots = [
         GenericUrdfReacher(urdf=urdf_file, mode="vel"),
     ]
-    env: UrdfEnv = gym.make("urdf-env-v0", dt=0.05, robots=robots, render=cfg.render)
+    env: UrdfEnv = gym.make("urdf-env-v0", dt=cfg.dt, robots=robots, render=cfg.render)
     # Set the initial position and velocity of the point mass.
     env.reset()
     goal_dict = {
@@ -101,10 +102,16 @@ def run_point_robot(cfg: ExampleConfig):
     for _ in range(cfg.n_steps):
         # Calculate action with the fabric planner, slice the states to drop Z-axis [3] information.
         ob_robot = ob["robot_0"]
+
+        # t = time.time()
+
         action = planner.compute_action(
             q=ob_robot["joint_state"]["position"],
             qdot=ob_robot["joint_state"]["velocity"],
         )
+
+        # print(f"Time: {(time.time() - t)} s")
+        
         (
             ob,
             *_,

--- a/examples/point_robot_custom_dynamics.py
+++ b/examples/point_robot_custom_dynamics.py
@@ -115,10 +115,11 @@ def run_point_robot(cfg: ExampleConfig):
 
         t = time.time()
 
-        action = planner.compute_action(
-            q=ob_robot["joint_state"]["position"],
-            qdot=ob_robot["joint_state"]["velocity"],
-        )
+        state = np.concatenate((ob_robot["joint_state"]["position"], ob_robot["joint_state"]["velocity"]))
+        
+        t = time.time()
+
+        action = planner.compute_action(state)
 
         print(f"Time: {(time.time() - t)} s")
         

--- a/examples/point_robot_custom_dynamics.py
+++ b/examples/point_robot_custom_dynamics.py
@@ -1,0 +1,116 @@
+import gym
+import numpy as np
+from urdfenvs.robots.generic_urdf import GenericUrdfReacher
+from urdfenvs.urdf_common.urdf_env import UrdfEnv
+from mppiisaac.planner.mppi_custom_dynamics import MPPICustomDynamicsPlanner
+import mppiisaac
+import hydra
+import yaml
+from yaml import SafeLoader
+from omegaconf import OmegaConf
+import os
+import torch
+from mpscenes.goals.static_sub_goal import StaticSubGoal
+from mppiisaac.utils.config_store import ExampleConfig
+
+# MPPI to navigate a simple robot to a goal position
+
+
+class Objective(object):
+    def __init__(self, cfg, device):
+        self.nav_goal = torch.tensor(cfg.goal, device=cfg.mppi.device)
+
+    def compute_cost(self, state: torch.Tensor):
+        positions = state[:, 0:2]
+        goal_dist = torch.linalg.norm(positions - self.nav_goal, axis=1)
+        return goal_dist * 1.0
+
+
+def initalize_environment(cfg) -> UrdfEnv:
+    """
+    Initializes the simulation environment.
+
+    Adds an obstacle and goal visualizaion to the environment and
+    steps the simulation once.
+
+    Params
+    ----------
+    render
+        Boolean toggle to set rendering on (True) or off (False).
+    """
+    with open(f'{os.path.dirname(mppiisaac.__file__)}/../conf/actors/point_robot.yaml') as f:
+        heijn_cfg = yaml.load(f, Loader=SafeLoader)
+    urdf_file = f'{os.path.dirname(mppiisaac.__file__)}/../assets/urdf/' + heijn_cfg['urdf_file']
+    robots = [
+        GenericUrdfReacher(urdf=urdf_file, mode="vel"),
+    ]
+    env: UrdfEnv = gym.make("urdf-env-v0", dt=0.05, robots=robots, render=cfg.render)
+    # Set the initial position and velocity of the point mass.
+    env.reset()
+    goal_dict = {
+        "weight": 1.0,
+        "is_primary_goal": True,
+        "indices": [0, 1],
+        "parent_link": 0,
+        "child_link": 1,
+        "desired_position": cfg.goal,
+        "epsilon": 0.05,
+        "type": "staticSubGoal",
+    }
+    goal = StaticSubGoal(name="simpleGoal", content_dict=goal_dict)
+    env.add_goal(goal)
+    return env
+
+
+def set_planner(cfg):
+    """
+    Initializes the mppi planner for the point robot.
+
+    Params
+    ----------
+    goal_position: np.ndarray
+        The goal to the motion planning problem.
+    """
+    # urdf = "../assets/point_robot.urdf"
+    objective = Objective(cfg, cfg.mppi.device)
+    planner = MPPICustomDynamicsPlanner(cfg, objective)
+
+    return planner
+
+
+@hydra.main(version_base=None, config_path="../conf", config_name="config_point_robot_custom_dynamics.yaml")
+def run_point_robot(cfg: ExampleConfig):
+    """
+    Set the gym environment, the planner and run point robot example.
+    The initial zero action step is needed to initialize the sensor in the
+    urdf environment.
+
+    Params
+    ----------
+    n_steps
+        Total number of simulation steps.
+    render
+        Boolean toggle to set rendering on (True) or off (False).
+    """
+    env = initalize_environment(cfg)
+    planner = set_planner(cfg)
+
+    action = np.zeros(int(cfg.nx / 2))
+    ob, *_ = env.step(action)
+
+    for _ in range(cfg.n_steps):
+        # Calculate action with the fabric planner, slice the states to drop Z-axis [3] information.
+        ob_robot = ob["robot_0"]
+        action = planner.compute_action(
+            q=ob_robot["joint_state"]["position"],
+            qdot=ob_robot["joint_state"]["velocity"],
+        )
+        (
+            ob,
+            *_,
+        ) = env.step(action)
+    return {}
+
+
+if __name__ == "__main__":
+    res = run_point_robot()

--- a/mppiisaac/dynamics/jackal_robot.py
+++ b/mppiisaac/dynamics/jackal_robot.py
@@ -1,0 +1,27 @@
+import torch
+
+def clip_actions(forward_velocity: torch.Tensor, rotational_velocity: torch.Tensor):
+    max_linear_vel = 0.5
+    max_rot_vel = 2
+    
+    # Clip forward and rotational velocities based on robot constraints
+    forward_velocity = torch.clamp(forward_velocity, -max_linear_vel, max_linear_vel)
+    rotational_velocity = torch.clamp(rotational_velocity, -max_rot_vel, max_rot_vel)
+    return forward_velocity, rotational_velocity
+
+def jackal_robot_dynamics(states: torch.Tensor, actions: torch.Tensor, dt: int) -> torch.Tensor:
+    x, y, theta, vx, vy, omega = states[:, 0], states[:, 1], states[:, 2], states[:, 3], states[:, 4], states[:, 5]
+
+    actions[:,0], actions[:,1] = clip_actions(actions[:,0], actions[:,1])
+
+    # Update velocity and position using bicycle model
+    new_vx = actions[:,0] * torch.cos(theta)
+    new_vy = actions[:,0] * torch.sin(theta)
+    new_omega = actions[:,1]
+
+    new_x = x + new_vx * dt
+    new_y = y + new_vy * dt
+    new_theta = theta + new_omega * dt
+
+    new_states = torch.stack([new_x, new_y, new_theta, new_vx, new_vy, new_omega], dim=1)
+    return new_states, actions

--- a/mppiisaac/dynamics/point_robot.py
+++ b/mppiisaac/dynamics/point_robot.py
@@ -1,11 +1,11 @@
 import torch
 
 def omnidirectional_point_robot_dynamics(states: torch.Tensor, actions: torch.Tensor, dt: int) -> torch.Tensor:
-    x, y, theta = states[:, 0], states[:, 1], states[:, 2]
+    x, y, theta, vx, vy, omega = states[:, 0], states[:, 1], states[:, 2], states[:, 3], states[:, 4], states[:, 5]
 
     new_x = x + actions[:, 0] * dt
     new_y = y + actions[:, 1] * dt
     new_theta = theta + actions[:, 2] * dt
 
-    new_states = torch.stack([new_x, new_y, new_theta], dim=1)
+    new_states = torch.stack([new_x, new_y, new_theta, vx, vy, omega], dim=1)
     return new_states

--- a/mppiisaac/dynamics/point_robot.py
+++ b/mppiisaac/dynamics/point_robot.py
@@ -1,0 +1,13 @@
+import torch
+
+def omnidirectional_point_robot_dynamics(states: torch.Tensor, actions: torch.Tensor, t: int) -> torch.Tensor:
+    x, y, theta = states[:, 0], states[:, 1], states[:, 2]
+
+    dt = 0.05
+
+    new_x = x + actions[:, 0] * dt
+    new_y = y + actions[:, 1] * dt
+    new_theta = theta + actions[:, 2] * dt
+
+    new_states = torch.stack([new_x, new_y, new_theta], dim=1)
+    return new_states

--- a/mppiisaac/dynamics/point_robot.py
+++ b/mppiisaac/dynamics/point_robot.py
@@ -1,9 +1,7 @@
 import torch
 
-def omnidirectional_point_robot_dynamics(states: torch.Tensor, actions: torch.Tensor, t: int) -> torch.Tensor:
+def omnidirectional_point_robot_dynamics(states: torch.Tensor, actions: torch.Tensor, dt: int) -> torch.Tensor:
     x, y, theta = states[:, 0], states[:, 1], states[:, 2]
-
-    dt = 0.05
 
     new_x = x + actions[:, 0] * dt
     new_y = y + actions[:, 1] * dt

--- a/mppiisaac/planner/isaacgym_wrapper.py
+++ b/mppiisaac/planner/isaacgym_wrapper.py
@@ -194,7 +194,7 @@ class IsaacGymWrapper:
 
         print(self.env_cfg)
 
-        self.obstacle_indices = torch.tensor([i for i, a in enumerate(self.env_cfg) if (a.type in ["sphere", "box"] and a.name != "dummy")], device=self.device)
+        self.obstacle_indices = torch.tensor([i for i, a in enumerate(self.env_cfg) if (a.type in ["sphere", "box"] and a.name != "dummy")], device=self.device).type(torch.int32)
 
         if self.ee_link_present:
             self.ee_positions = self.rigid_body_state[

--- a/mppiisaac/planner/mppi_custom_dynamics.py
+++ b/mppiisaac/planner/mppi_custom_dynamics.py
@@ -1,0 +1,51 @@
+from mppiisaac.planner.mppi import MPPIPlanner
+from typing import Callable, Optional
+import io
+import os
+import yaml
+from yaml.loader import SafeLoader
+from mppiisaac.dynamics.point_robot import omnidirectional_point_robot_dynamics
+
+import torch
+
+torch.set_printoptions(precision=2, sci_mode=False)
+
+
+class MPPICustomDynamicsPlanner(object):
+    """
+    Wrapper class that inherits from the MPPIPlanner and implements the required functions:
+        dynamics, running_cost, and terminal_cost
+    """
+
+    def __init__(self, cfg, objective: Callable):
+        self.cfg = cfg
+        self.objective = objective
+
+        self.mppi = MPPIPlanner(
+            cfg.mppi,
+            cfg.nx,
+            dynamics=self.dynamics,
+            running_cost=self.running_cost
+        )
+        self.current_state = torch.zeros((self.cfg.mppi.num_samples, self.cfg.nx))
+    
+    def update_objective(self, objective):
+        self.objective = objective
+
+    def dynamics(self, states, control, t):
+        new_states = omnidirectional_point_robot_dynamics(states, control, t)
+        return (new_states, control)
+
+    def running_cost(self, state):
+        # Note: again normally mppi passes the state as a parameter in the running cost call, but using isaacgym the state is already saved and accesible in the simulator itself, so we ignore it and pass a handle to the simulator.
+        return self.objective.compute_cost(state)
+
+    def compute_action(self, q, qdot):
+        q_tensor = torch.tensor([q], dtype=torch.float32, device=self.cfg.mppi.device)
+        qdot_tensor = torch.tensor([qdot], dtype=torch.float32, device=self.cfg.mppi.device)
+        print(f"q_tensor: {q_tensor} {q_tensor.shape} {q_tensor.dtype}")
+        print(f"qdot_tensor: {qdot_tensor} {qdot_tensor.shape} {qdot_tensor.dtype}")
+        self.current_state = torch.cat([q_tensor, qdot_tensor], dim=1)
+
+        actions = self.mppi.command(self.current_state).cpu()
+        return actions

--- a/mppiisaac/planner/mppi_custom_dynamics.py
+++ b/mppiisaac/planner/mppi_custom_dynamics.py
@@ -31,10 +31,12 @@ class MPPICustomDynamicsPlanner(object):
     def running_cost(self, state):
         return self.objective.compute_cost(state)
 
-    def compute_action(self, q, qdot):
-        q_tensor = torch.tensor([q], dtype=torch.float32, device=self.cfg.mppi.device)
-        qdot_tensor = torch.tensor([qdot], dtype=torch.float32, device=self.cfg.mppi.device)
-        self.current_state = torch.cat([q_tensor, qdot_tensor], dim=1)
+    def compute_action(self, state):
+        # q_tensor = torch.tensor([q], dtype=torch.float32, device=self.cfg.mppi.device)
+        # qdot_tensor = torch.tensor([qdot], dtype=torch.float32, device=self.cfg.mppi.device)
+        # self.current_state = torch.cat([q_tensor, qdot_tensor], dim=1)
+
+        self.current_state = torch.tensor([state], dtype=torch.float32, device=self.cfg.mppi.device)
 
         actions = self.mppi.command(self.current_state).cpu()
         return actions

--- a/mppiisaac/planner/mppi_custom_dynamics.py
+++ b/mppiisaac/planner/mppi_custom_dynamics.py
@@ -1,10 +1,5 @@
 from mppiisaac.planner.mppi import MPPIPlanner
-from typing import Callable, Optional
-import io
-import os
-import yaml
-from yaml.loader import SafeLoader
-from mppiisaac.dynamics.point_robot import omnidirectional_point_robot_dynamics
+from typing import Callable
 
 import torch
 
@@ -17,9 +12,10 @@ class MPPICustomDynamicsPlanner(object):
         dynamics, running_cost, and terminal_cost
     """
 
-    def __init__(self, cfg, objective: Callable):
+    def __init__(self, cfg, objective: Callable, dynamics: Callable):
         self.cfg = cfg
         self.objective = objective
+        self.dynamics = dynamics
 
         self.mppi = MPPIPlanner(
             cfg.mppi,
@@ -31,10 +27,6 @@ class MPPICustomDynamicsPlanner(object):
     
     def update_objective(self, objective):
         self.objective = objective
-
-    def dynamics(self, states, control, t):
-        new_states = omnidirectional_point_robot_dynamics(states, control, self.cfg.dt)
-        return (new_states, control)
 
     def running_cost(self, state):
         return self.objective.compute_cost(state)

--- a/mppiisaac/planner/mppi_custom_dynamics.py
+++ b/mppiisaac/planner/mppi_custom_dynamics.py
@@ -33,18 +33,15 @@ class MPPICustomDynamicsPlanner(object):
         self.objective = objective
 
     def dynamics(self, states, control, t):
-        new_states = omnidirectional_point_robot_dynamics(states, control, t)
+        new_states = omnidirectional_point_robot_dynamics(states, control, self.cfg.dt)
         return (new_states, control)
 
     def running_cost(self, state):
-        # Note: again normally mppi passes the state as a parameter in the running cost call, but using isaacgym the state is already saved and accesible in the simulator itself, so we ignore it and pass a handle to the simulator.
         return self.objective.compute_cost(state)
 
     def compute_action(self, q, qdot):
         q_tensor = torch.tensor([q], dtype=torch.float32, device=self.cfg.mppi.device)
         qdot_tensor = torch.tensor([qdot], dtype=torch.float32, device=self.cfg.mppi.device)
-        print(f"q_tensor: {q_tensor} {q_tensor.shape} {q_tensor.dtype}")
-        print(f"qdot_tensor: {qdot_tensor} {qdot_tensor.shape} {qdot_tensor.dtype}")
         self.current_state = torch.cat([q_tensor, qdot_tensor], dim=1)
 
         actions = self.mppi.command(self.current_state).cpu()

--- a/mppiisaac/planner/mppi_isaac.py
+++ b/mppiisaac/planner/mppi_isaac.py
@@ -46,6 +46,7 @@ class MPPIisaacPlanner(object):
             actors=actors,
             init_positions=cfg.initial_actor_positions,
             num_envs=cfg.mppi.num_samples,
+            device=cfg.mppi.device
         )
 
         if prior:

--- a/mppiisaac/utils/config_store.py
+++ b/mppiisaac/utils/config_store.py
@@ -1,9 +1,98 @@
 from dataclasses import dataclass, field
-from mppiisaac.planner.mppi import MPPIConfig
-from mppiisaac.planner.isaacgym_wrapper import IsaacGymConfig, ActorWrapper
 from hydra.core.config_store import ConfigStore
 
 from typing import List, Optional
+from enum import Enum
+
+class SupportedActorTypes(Enum):
+    Axis = 1
+    Robot = 2
+    Sphere = 3
+    Box = 4
+
+
+@dataclass
+class ActorWrapper:
+    type: SupportedActorTypes
+    name: str
+    init_pos: List[float] = field(default_factory=lambda: [0, 0, 0])
+    init_ori: List[float] = field(default_factory=lambda: [0, 0, 0, 1])
+    size: List[float] = field(default_factory=lambda: [0.1, 0.1, 0.1])
+    mass: float = 1.0  # kg
+    color: List[float] = field(default_factory=lambda: [1.0, 1.0, 1.0])
+    fixed: bool = False
+    collision: bool = True
+    friction: float = 1.
+    handle: Optional[int] = None
+    flip_visual: bool = False
+    urdf_file: str = None
+    ee_link: str = None
+    gravity: bool = True
+    differential_drive: bool = False
+    wheel_radius: Optional[float] = None
+    wheel_base: Optional[float] = None
+    wheel_count: Optional[float] = None
+    left_wheel_joints: Optional[List[int]] = None
+    right_wheel_joints: Optional[List[int]] = None
+    caster_links: Optional[List[str]] = None
+    noise_sigma_size: Optional[List[float]] = None
+    noise_percentage_mass: float = 0.0
+    noise_percentage_friction: float = 0.0
+
+
+@dataclass
+class MPPIConfig(object):
+    """
+        :param num_samples: K, number of trajectories to sample
+        :param horizon: T, length of each trajectory
+        :param mppi_mode: 'halton-spline' or 'simple' corresponds to the type of mppi.
+        :param sampling_method: 'halton' or 'random', sampling strategy while using mode 'halton-spline'. In 'simple', random sampling is forced to 'random' 
+        :param noise_sigma: variance per action
+        :param noise_mu: (nu) control noise mean (used to bias control samples); defaults to zero mean        
+        :param device: pytorch device
+        :param lambda_: inverse temperature, positive scalar where smaller values will allow more exploration
+        :param update_lambda: flag for updating inv temperature
+        :param update_cov: flag for updating covariance
+        :param u_min: (nu) minimum values for each dimension of control to pass into dynamics
+        :param u_max: (nu) maximum values for each dimension of control to pass into dynamics
+        :param u_init: (nu) what to initialize new end of trajectory control to be; defeaults to zero
+        :param U_init: (T x nu) initial control sequence; defaults to noise
+        :param rollout_var_discount: Discount cost over control horizon
+        :param sample_null_action: Whether to explicitly sample a null action (bad for starting in a local minima)
+        :param noise_abs_cost: Whether to use the absolute value of the action noise to avoid bias when all states have the same cost   
+    """
+
+    num_samples: int = 100
+    horizon: int = 30
+    mppi_mode: str = 'halton-spline'
+    sampling_method: str = "halton"
+    noise_sigma: Optional[List[List[float]]] = None
+    noise_mu: Optional[List[float]] = None
+    device: str = "cuda:0"
+    lambda_: float = 0.0
+    update_lambda: bool = False
+    update_cov: bool = False
+    u_min: Optional[List[float]] = None
+    u_max: Optional[List[float]] = None
+    u_init: float = 0.0
+    U_init: Optional[List[List[float]]] = None
+    u_scale: float = 1
+    u_per_command: int = 1
+    rollout_var_discount: float = 0.95
+    sample_null_action: bool = False
+    noise_abs_cost: bool = False
+    filter_u: bool = False
+    use_priors: bool = False
+
+@dataclass
+class IsaacGymConfig(object):
+    dt: float = 0.05
+    substeps: int = 2
+    use_gpu_pipeline: bool = True
+    num_client_threads: int = 0
+    viewer: bool = False
+    num_obstacles: int = 10
+    spacing: float = 6.0
 
 
 @dataclass


### PR DESCRIPTION
Adds examples with custom dynamics for single and multi-agent motion planning with the point and jackal robots.

Also adds used cfg.device to switch between CPU and GPU.